### PR TITLE
Added missing parameter 'visited'

### DIFF
--- a/meteor_reasoner/materialization/seminaive_join.py
+++ b/meteor_reasoner/materialization/seminaive_join.py
@@ -107,7 +107,7 @@ def seminaive_join(rule, D,  delta_old, delta_new, D_index=None, must_literals=N
             current_literal = copy.deepcopy(literals[global_literal_index])
             if not isinstance(current_literal, BinaryLiteral):
                 if current_literal.get_predicate() in ["Bottom", "Top"]:
-                    ground_body(global_literal_index+1, delta, context)
+                    ground_body(global_literal_index+1, visited, delta, context)
                 else:
                     for tmp_entity, tmp_context in ground_generator(current_literal, context, D, D_index, delta_old, global_literal_index==visited, global_literal_index > visited):
                         tmp_delata = {global_literal_index: [tmp_entity]}


### PR DESCRIPTION
In seminaive_join.py, line 110 calls function ground_body() with three parameters instead of four, resulting in a TypeError.
This specific line is only encountered when either 'Top' or 'Bottom' is in the dataset and in one of the rule bodies of the program.

This error can be encountered when running materialize() with the following minimal example:
dataset: Top@0
program: A:-Top