### PR TITLE
Added missing parameter 'visited'

### DIFF
--- a/meteor_reasoner/materialization/seminaive_join.py
+++ b/meteor_reasoner/materialization/seminaive_join.py
@@ -107,7 +107,7 @@ def seminaive_join(rule, D,  delta_old, delta_new, D_index=None, must_literals=N
             current_literal = copy.deepcopy(literals[global_literal_index])
             if not isinstance(current_literal, BinaryLiteral):
                 if current_literal.get_predicate() in ["Bottom", "Top"]:
-                    ground_body(global_literal_index+1, delta, context)
+                    ground_body(global_literal_index+1, visited, delta, context)
                 else:
                     for tmp_entity, tmp_context in ground_generator(current_literal, context, D, D_index, delta_old, global_literal_index==visited, global_literal_index > visited):
                         tmp_delata = {global_literal_index: [tmp_entity]}

--- a/meteor_reasoner/utils/parser.py
+++ b/meteor_reasoner/utils/parser.py
@@ -59,11 +59,8 @@ def parse_rule(line):
                 raise Exception("{} has an incorrect syntax!".format(literal_str))
             negative_body.append(literal)
 
-    ordered_literals = []
-    for literal in literals:
-        if isinstance(literal, BinaryLiteral):
-            ordered_literals.append(literal)
-            literals.remove(literal)
+    ordered_literals    = [ lit for lit in literals if isinstance(lit, BinaryLiteral) ]
+    literals = [ lit for lit in literals if not ( lit in ordered_literals ) ]
     literals = sorted(literals, key=lambda item: len(item.get_entity()), reverse=True)
     ordered_literals = ordered_literals + literals
     rule = Rule(head_atom, ordered_literals, negative_body=negative_body)


### PR DESCRIPTION
[Redo of accidentally closed pull request after branch renaming]

In seminaive_join.py, line 110 calls function ground_body() with three parameters instead of four, resulting in a TypeError.
This specific line is only encountered when either 'Top' or 'Bottom' is in the dataset and in one of the rule bodies of the program.

This error can be encountered when running materialize() with the following minimal example:
dataset: Top@0
program: A:-Top